### PR TITLE
[TASK-004] Define Sync Command Structure

### DIFF
--- a/src/main/java/com/github/bfalmeida/photosync/cli/SyncCommand.java
+++ b/src/main/java/com/github/bfalmeida/photosync/cli/SyncCommand.java
@@ -1,0 +1,56 @@
+package com.github.bfalmeida.photosync.cli;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.shell.standard.ShellComponent;
+import org.springframework.shell.standard.ShellMethod;
+import org.springframework.shell.standard.ShellOption;
+
+import java.io.File;
+
+@ShellComponent
+public class SyncCommand {
+
+    private static final Logger log = LoggerFactory.getLogger(SyncCommand.class);
+
+    @ShellMethod(key = "sync", value = "Synchronize photos from source to destination")
+    public String sync(
+            @ShellOption(help = "Source directory containing photos") String source,
+            @ShellOption(help = "Destination directory for photos") String destination,
+            @ShellOption(defaultValue = "true", help = "Preview changes without executing") boolean dryRun,
+            @ShellOption(help = "Execute the sync operation") boolean execute,
+            @ShellOption(help = "Folder for files without date metadata") String undatedFolder,
+            @ShellOption(help = "Skip files without date metadata") boolean skipUndated,
+            @ShellOption(help = "Logging level (DEBUG, INFO, WARN, ERROR)") String logLevel,
+            @ShellOption(help = "Log file path") String logFile
+    ) {
+        log.info("Sync command options received:");
+        log.info("  source: {}", source);
+        log.info("  destination: {}", destination);
+        log.info("  dry-run: {}", dryRun);
+        log.info("  execute: {}", execute);
+        log.info("  undated-folder: {}", undatedFolder);
+        log.info("  skip-undated: {}", skipUndated);
+        log.info("  log-level: {}", logLevel);
+        log.info("  log-file: {}", logFile);
+
+        if (!new File(source).isAbsolute() && !new File(source).exists()) {
+            log.warn("Source path is not absolute and may not exist: {}", source);
+        }
+
+        if (!new File(destination).isAbsolute() && !new File(destination).exists()) {
+            log.warn("Destination path is not absolute and may not exist: {}", destination);
+        }
+
+        boolean willExecute = execute && !dryRun;
+        if (!willExecute) {
+            log.info("Running in dry-run mode. Use --execute to perform actual operations.");
+        }
+
+        int copied = 0;
+        int skipped = 0;
+        int errors = 0;
+
+        return String.format("Done: %d copied, %d skipped, %d errors", copied, skipped, errors);
+    }
+}

--- a/src/test/java/com/github/bfalmeida/photosync/cli/SyncCommandTest.java
+++ b/src/test/java/com/github/bfalmeida/photosync/cli/SyncCommandTest.java
@@ -1,0 +1,185 @@
+package com.github.bfalmeida.photosync.cli;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SyncCommandTest {
+
+    private static final Logger log = LoggerFactory.getLogger(SyncCommandTest.class);
+
+    private SyncCommand syncCommand;
+
+    @BeforeEach
+    void setUp() {
+        syncCommand = new SyncCommand();
+    }
+
+    @Test
+    void testDryRunDefaultValue() {
+        String result = syncCommand.sync(
+                "/tmp/source",
+                "/tmp/dest",
+                true,
+                false,
+                null,
+                false,
+                null,
+                null
+        );
+
+        assertThat(result).contains("Done:");
+        log.info("Test dry-run default: {}", result);
+    }
+
+    @Test
+    void testSkipUndatedDefaultValue() {
+        String result = syncCommand.sync(
+                "/tmp/source",
+                "/tmp/dest",
+                true,
+                false,
+                null,
+                false,
+                "INFO",
+                null
+        );
+
+        assertThat(result).contains("Done:");
+        log.info("Test skip-undated default: {}", result);
+    }
+
+    @Test
+    void testLogLevelDefaultValue() {
+        String result = syncCommand.sync(
+                "/tmp/source",
+                "/tmp/dest",
+                true,
+                false,
+                null,
+                false,
+                null,
+                null
+        );
+
+        assertThat(result).contains("Done:");
+        log.info("Test log-level default: {}", result);
+    }
+
+    @Test
+    void testSyncCommandRunsAndPrintsSummary() {
+        String result = syncCommand.sync(
+                "/tmp/source",
+                "/tmp/dest",
+                true,
+                false,
+                null,
+                false,
+                "INFO",
+                null
+        );
+
+        assertThat(result).isEqualTo("Done: 0 copied, 0 skipped, 0 errors");
+    }
+
+    @Test
+    void testWithExecuteFlag() {
+        String result = syncCommand.sync(
+                "/tmp/source",
+                "/tmp/dest",
+                false,
+                true,
+                null,
+                false,
+                "INFO",
+                null
+        );
+
+        assertThat(result).isEqualTo("Done: 0 copied, 0 skipped, 0 errors");
+    }
+
+    @Test
+    void testWithSkipUndatedFlag() {
+        String result = syncCommand.sync(
+                "/tmp/source",
+                "/tmp/dest",
+                true,
+                false,
+                null,
+                true,
+                "INFO",
+                null
+        );
+
+        assertThat(result).isEqualTo("Done: 0 copied, 0 skipped, 0 errors");
+    }
+
+    @Test
+    void testWithInvalidSourcePath() {
+        String result = syncCommand.sync(
+                "invalid-source",
+                "/tmp/dest",
+                true,
+                false,
+                null,
+                false,
+                "INFO",
+                null
+        );
+
+        assertThat(result).isEqualTo("Done: 0 copied, 0 skipped, 0 errors");
+    }
+
+    @Test
+    void testWithInvalidDestinationPath() {
+        String result = syncCommand.sync(
+                "/tmp/source",
+                "invalid-dest",
+                true,
+                false,
+                null,
+                false,
+                "INFO",
+                null
+        );
+
+        assertThat(result).isEqualTo("Done: 0 copied, 0 skipped, 0 errors");
+    }
+
+    @Test
+    void testWithMissingSourceAndDestination() {
+        String result = syncCommand.sync(
+                "",
+                "",
+                true,
+                false,
+                null,
+                false,
+                "INFO",
+                null
+        );
+
+        assertThat(result).isEqualTo("Done: 0 copied, 0 skipped, 0 errors");
+    }
+
+    @Test
+    void testAbsolutePathsDoNotTriggerWarning() {
+        String result = syncCommand.sync(
+                "/absolute/source",
+                "/absolute/dest",
+                true,
+                false,
+                null,
+                false,
+                "INFO",
+                null
+        );
+
+        assertThat(result).isEqualTo("Done: 0 copied, 0 skipped, 0 errors");
+    }
+}


### PR DESCRIPTION
## Summary
- Implements the sync command structure for the photo synchronization CLI
- Defines CLI options for source/destination directories, dry-run mode, execute flag, undated folder handling, and logging configuration
- Adds input validation for path parameters with warning logs
- Provides summary output showing copied, skipped, and error counts

Closes #7