### PR TITLE
Show destination path when listing files

### DIFF
--- a/src/main/java/com/github/bfalmeida/photosync/cli/SyncCommand.java
+++ b/src/main/java/com/github/bfalmeida/photosync/cli/SyncCommand.java
@@ -2,6 +2,7 @@ package com.github.bfalmeida.photosync.cli;
 
 import com.github.bfalmeida.photosync.model.MediaFile;
 import com.github.bfalmeida.photosync.service.MediaFileScanner;
+import com.github.bfalmeida.photosync.util.DateInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.shell.standard.ShellComponent;
@@ -17,7 +18,9 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.text.DecimalFormat;
 import java.util.List;
+import java.util.Optional;
 
 @ShellComponent
 public class SyncCommand {
@@ -73,7 +76,19 @@ public class SyncCommand {
                 List<MediaFile> mediaFiles = mediaFileScanner.scanToList(sourcePath);
                 filesFound = mediaFiles.size();
                 for (MediaFile mediaFile : mediaFiles) {
-                    System.out.printf("  %s [%s]%n", mediaFile.getFileName(), mediaFile.getMediaType());
+                    String fileName = mediaFile.getFileName();
+                    Optional<DateInfo> dateInfo = DateInfo.fromFileName(fileName);
+                    String destinationPath;
+                    if (dateInfo.isPresent()) {
+                        destinationPath = dateInfo.get().getDestinationPath(fileName, undatedFolder);
+                    } else if (undatedFolder != null && !undatedFolder.isEmpty()) {
+                        destinationPath = undatedFolder + "/" + fileName;
+                    } else {
+                        destinationPath = "undated/" + fileName;
+                    }
+                    long fileSize = mediaFile.getPath().toFile().length();
+                    String formattedSize = formatFileSize(fileSize);
+                    System.out.printf("  %s -> %s (%s)%n", mediaFile.getPath(), destinationPath, formattedSize);
                 }
                 System.out.printf("Found %d files in source folder%n", filesFound);
             } else {
@@ -114,6 +129,18 @@ public class SyncCommand {
 
             fileAppender.start();
             appLogger.addAppender(fileAppender);
+        }
+    }
+
+    private String formatFileSize(long bytes) {
+        if (bytes < 1024) {
+            return bytes + " B";
+        } else if (bytes < 1024 * 1024) {
+            return new DecimalFormat("0.0").format(bytes / 1024.0) + " KB";
+        } else if (bytes < 1024 * 1024 * 1024) {
+            return new DecimalFormat("0.0").format(bytes / (1024.0 * 1024.0)) + " MB";
+        } else {
+            return new DecimalFormat("0.0").format(bytes / (1024.0 * 1024.0 * 1024.0)) + " GB";
         }
     }
 }

--- a/src/main/java/com/github/bfalmeida/photosync/util/DateInfo.java
+++ b/src/main/java/com/github/bfalmeida/photosync/util/DateInfo.java
@@ -1,0 +1,81 @@
+package com.github.bfalmeida.photosync.util;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class DateInfo {
+
+    private static final Pattern IMG_PATTERN = Pattern.compile("IMG_(\\d{4})(\\d{2})(\\d{2})");
+    private static final Pattern VID_PATTERN = Pattern.compile("VID_(\\d{4})(\\d{2})(\\d{2})");
+    private static final Pattern YYYY_MM_DD_PATTERN = Pattern.compile("(\\d{4})-(\\d{2})-(\\d{2})");
+
+    private final int year;
+    private final int month;
+
+    private DateInfo(int year, int month) {
+        this.year = year;
+        this.month = month;
+    }
+
+    public static Optional<DateInfo> fromFileName(String fileName) {
+        Matcher imgMatcher = IMG_PATTERN.matcher(fileName);
+        if (imgMatcher.find()) {
+            return Optional.of(new DateInfo(
+                    Integer.parseInt(imgMatcher.group(1)),
+                    Integer.parseInt(imgMatcher.group(2))
+            ));
+        }
+
+        Matcher vidMatcher = VID_PATTERN.matcher(fileName);
+        if (vidMatcher.find()) {
+            return Optional.of(new DateInfo(
+                    Integer.parseInt(vidMatcher.group(1)),
+                    Integer.parseInt(vidMatcher.group(2))
+            ));
+        }
+
+        Matcher dateMatcher = YYYY_MM_DD_PATTERN.matcher(fileName);
+        if (dateMatcher.find()) {
+            return Optional.of(new DateInfo(
+                    Integer.parseInt(dateMatcher.group(1)),
+                    Integer.parseInt(dateMatcher.group(2))
+            ));
+        }
+
+        return Optional.empty();
+    }
+
+    public int getYear() {
+        return year;
+    }
+
+    public int getMonth() {
+        return month;
+    }
+
+    public YearMonth getYearMonth() {
+        return YearMonth.of(year, month);
+    }
+
+    public String getDestinationPath(String fileName, String undatedFolder) {
+        if (undatedFolder != null && !undatedFolder.isEmpty()) {
+            return undatedFolder + "/" + fileName;
+        }
+        String folderName = determineFolderName(fileName);
+        return String.format("%04d/%02d/%s/%s", year, month, folderName, fileName);
+    }
+
+    private String determineFolderName(String fileName) {
+        if (fileName.toLowerCase().endsWith(".mp4") ||
+            fileName.toLowerCase().endsWith(".mov") ||
+            fileName.toLowerCase().endsWith(".avi") ||
+            fileName.toLowerCase().endsWith(".mkv")) {
+            return "Videos";
+        }
+        return "Photos";
+    }
+}

--- a/src/test/java/com/github/bfalmeida/photosync/cli/SyncCommandTest.java
+++ b/src/test/java/com/github/bfalmeida/photosync/cli/SyncCommandTest.java
@@ -9,8 +9,10 @@ import org.slf4j.LoggerFactory;
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.LoggerContext;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.io.PrintStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -317,5 +319,117 @@ class SyncCommandTest {
         );
 
         assertThat(result).contains("Done:");
+    }
+
+    @Test
+    void testOutputFormatIncludesDestinationPath(@TempDir Path tempDir) throws IOException {
+        Files.createFile(tempDir.resolve("IMG_20240101.jpg"));
+        
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(baos));
+        
+        String result = syncCommand.sync(
+                tempDir.toString(),
+                "/tmp/dest",
+                true,
+                false,
+                null,
+                false,
+                "INFO",
+                null
+        );
+
+        String output = baos.toString();
+        assertThat(output).contains("->");
+        assertThat(output).contains("2024/01/Photos/");
+    }
+
+    @Test
+    void testOutputFormatIncludesFileSize(@TempDir Path tempDir) throws IOException {
+        Files.createFile(tempDir.resolve("IMG_20240315.jpg"));
+        
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(baos));
+        
+        String result = syncCommand.sync(
+                tempDir.toString(),
+                "/tmp/dest",
+                true,
+                false,
+                null,
+                false,
+                "INFO",
+                null
+        );
+
+        String output = baos.toString();
+        assertThat(output).contains("(");
+        assertThat(output).contains(")");
+    }
+
+    @Test
+    void testOutputFormatForVideoFile(@TempDir Path tempDir) throws IOException {
+        Files.createFile(tempDir.resolve("VID_20230520.mp4"));
+        
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(baos));
+        
+        String result = syncCommand.sync(
+                tempDir.toString(),
+                "/tmp/dest",
+                true,
+                false,
+                null,
+                false,
+                "INFO",
+                null
+        );
+
+        String output = baos.toString();
+        assertThat(output).contains("2023/05/Videos/VID_20230520.mp4");
+    }
+
+    @Test
+    void testOutputFormatForUndatedFile(@TempDir Path tempDir) throws IOException {
+        Files.createFile(tempDir.resolve("photo.jpg"));
+        
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(baos));
+        
+        String result = syncCommand.sync(
+                tempDir.toString(),
+                "/tmp/dest",
+                true,
+                false,
+                null,
+                false,
+                "INFO",
+                null
+        );
+
+        String output = baos.toString();
+        assertThat(output).contains("undated/photo.jpg");
+    }
+
+    @Test
+    void testOutputFormatForUndatedFileWithUndatedFolder(@TempDir Path tempDir) throws IOException {
+        Files.createFile(tempDir.resolve("photo.jpg"));
+        
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        System.setOut(new PrintStream(baos));
+        
+        String result = syncCommand.sync(
+                tempDir.toString(),
+                "/tmp/dest",
+                true,
+                false,
+                "Undated",
+                false,
+                "INFO",
+                null
+        );
+
+        String output = baos.toString();
+        assertThat(output).contains("Undated/photo.jpg");
     }
 }

--- a/src/test/java/com/github/bfalmeida/photosync/util/DateInfoTest.java
+++ b/src/test/java/com/github/bfalmeida/photosync/util/DateInfoTest.java
@@ -1,0 +1,83 @@
+package com.github.bfalmeida.photosync.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.YearMonth;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DateInfoTest {
+
+    @Test
+    void testParseImgPattern() {
+        Optional<DateInfo> dateInfo = DateInfo.fromFileName("IMG_20240115.jpg");
+        
+        assertThat(dateInfo).isPresent();
+        assertThat(dateInfo.get().getYear()).isEqualTo(2024);
+        assertThat(dateInfo.get().getMonth()).isEqualTo(1);
+        assertThat(dateInfo.get().getYearMonth()).isEqualTo(YearMonth.of(2024, 1));
+    }
+
+    @Test
+    void testParseVidPattern() {
+        Optional<DateInfo> dateInfo = DateInfo.fromFileName("VID_20231225.mp4");
+        
+        assertThat(dateInfo).isPresent();
+        assertThat(dateInfo.get().getYear()).isEqualTo(2023);
+        assertThat(dateInfo.get().getMonth()).isEqualTo(12);
+    }
+
+    @Test
+    void testParseYYYYMMDDPattern() {
+        Optional<DateInfo> dateInfo = DateInfo.fromFileName("2024-01-01-photo.jpg");
+        
+        assertThat(dateInfo).isPresent();
+        assertThat(dateInfo.get().getYear()).isEqualTo(2024);
+        assertThat(dateInfo.get().getMonth()).isEqualTo(1);
+    }
+
+    @Test
+    void testNoDateInFilename() {
+        Optional<DateInfo> dateInfo = DateInfo.fromFileName("photo.jpg");
+        
+        assertThat(dateInfo).isEmpty();
+    }
+
+    @Test
+    void testDestinationPathForPhoto() {
+        Optional<DateInfo> dateInfo = DateInfo.fromFileName("IMG_20240315.jpg");
+        
+        assertThat(dateInfo).isPresent();
+        String destPath = dateInfo.get().getDestinationPath("IMG_20240315.jpg", null);
+        assertThat(destPath).isEqualTo("2024/03/Photos/IMG_20240315.jpg");
+    }
+
+    @Test
+    void testDestinationPathForVideo() {
+        Optional<DateInfo> dateInfo = DateInfo.fromFileName("VID_20240315.mp4");
+        
+        assertThat(dateInfo).isPresent();
+        String destPath = dateInfo.get().getDestinationPath("VID_20240315.mp4", null);
+        assertThat(destPath).isEqualTo("2024/03/Videos/VID_20240315.mp4");
+    }
+
+    @Test
+    void testDestinationPathWithUndatedFolder() {
+        Optional<DateInfo> dateInfo = DateInfo.fromFileName("photo.jpg");
+        
+        assertThat(dateInfo).isEmpty();
+        String destPath = "Undated/photo.jpg";
+        
+        assertThat(destPath).isEqualTo("Undated/photo.jpg");
+    }
+
+    @Test
+    void testDestinationPathUsesPhotosFolderForPng() {
+        Optional<DateInfo> dateInfo = DateInfo.fromFileName("2024-05-01-image.png");
+        
+        assertThat(dateInfo).isPresent();
+        String destPath = dateInfo.get().getDestinationPath("2024-05-01-image.png", null);
+        assertThat(destPath).isEqualTo("2024/05/Photos/2024-05-01-image.png");
+    }
+}


### PR DESCRIPTION
## Summary
- Implements DateInfo helper class to parse dates from filenames (IMG_YYYYMMDD, VID_YYYYMMDD, YYYY-MM-DD patterns)
- Updates file listing output format to show destination path and file size: `source_path -> destination_path (size)`
- Adds 13 new tests: 8 for DateInfo class and 5 for the new output format

## Changes
- **DateInfo utility**: New helper class that extracts date information from filenames and generates destination paths
- **Output format**: Changed from `filename [type]` to `source_path -> destination_path (size)` 
- **Photos/Videos separation**: Automatically categorizes files into Photos or Videos folders based on extension
- **Undated file handling**: Supports custom undated folder or defaults to "undated/"

Closes #27