### PR TITLE
feat: Add missing RAW extensions and fix RAW file routing

### DIFF
--- a/src/main/java/com/github/bfalmeida/photosync/model/MediaType.java
+++ b/src/main/java/com/github/bfalmeida/photosync/model/MediaType.java
@@ -2,5 +2,6 @@ package com.github.bfalmeida.photosync.model;
 
 public enum MediaType {
     PHOTO,
-    VIDEO
+    VIDEO,
+    RAW
 }

--- a/src/main/java/com/github/bfalmeida/photosync/service/FileCopyService.kt
+++ b/src/main/java/com/github/bfalmeida/photosync/service/FileCopyService.kt
@@ -24,13 +24,22 @@ class FileCopyService(private val hashingService: HashingService) {
             var destinationFolder: Path
 
             if (dateTime == null) {
+                val typeFolder = when (mediaFile.mediaType) {
+                    MediaType.PHOTO -> "Photos"
+                    MediaType.VIDEO -> "Videos"
+                    MediaType.RAW -> "raw"
+                }
                 val folderName = if (undatedFolder.isNullOrEmpty()) "undated" else undatedFolder
-                destinationFolder = destinationRoot.resolve(folderName)
+                destinationFolder = destinationRoot.resolve(folderName).resolve(typeFolder)
             } else {
                 val year = dateTime.year
                 val month = dateTime.monthValue
 
-                val folderName = if (mediaFile.mediaType == MediaType.PHOTO) "Photos" else "Videos"
+                val folderName = when (mediaFile.mediaType) {
+                    MediaType.PHOTO -> "Photos"
+                    MediaType.VIDEO -> "Videos"
+                    MediaType.RAW -> "raw"
+                }
 
                 destinationFolder = destinationRoot
                     .resolve(year.toString())

--- a/src/main/java/com/github/bfalmeida/photosync/service/FileCopyService.kt
+++ b/src/main/java/com/github/bfalmeida/photosync/service/FileCopyService.kt
@@ -36,12 +36,7 @@ class FileCopyService(private val hashingService: HashingService) {
                 val year = dateTime.year
                 val month = dateTime.monthValue
 
-                val folderName = when (mediaFile.mediaType) {
-                    MediaType.PHOTO -> "Photos"
-                    MediaType.VIDEO -> "Videos"
-                    MediaType.RAW -> "raw"
-                    else -> "unknown"
-                }
+                val folderName = when (mediaFile.mediaType) { MediaType.PHOTO -> "Photos"; MediaType.VIDEO -> "Videos"; MediaType.RAW -> "raw"; else -> "unknown" }
 
                 destinationFolder = destinationRoot
                     .resolve(year.toString())

--- a/src/main/java/com/github/bfalmeida/photosync/service/FileCopyService.kt
+++ b/src/main/java/com/github/bfalmeida/photosync/service/FileCopyService.kt
@@ -28,6 +28,7 @@ class FileCopyService(private val hashingService: HashingService) {
                     MediaType.PHOTO -> "Photos"
                     MediaType.VIDEO -> "Videos"
                     MediaType.RAW -> "raw"
+                    else -> "unknown"
                 }
                 val folderName = if (undatedFolder.isNullOrEmpty()) "undated" else undatedFolder
                 destinationFolder = destinationRoot.resolve(folderName).resolve(typeFolder)
@@ -39,6 +40,7 @@ class FileCopyService(private val hashingService: HashingService) {
                     MediaType.PHOTO -> "Photos"
                     MediaType.VIDEO -> "Videos"
                     MediaType.RAW -> "raw"
+                    else -> "unknown"
                 }
 
                 destinationFolder = destinationRoot

--- a/src/main/java/com/github/bfalmeida/photosync/service/MediaFileScanner.kt
+++ b/src/main/java/com/github/bfalmeida/photosync/service/MediaFileScanner.kt
@@ -16,7 +16,10 @@ class MediaFileScanner {
         private val PHOTO_EXTENSIONS = setOf(
             "jpg", "jpeg", "png", "gif", "bmp", "heic", "heif"
         )
-
+        private val RAW_EXTENSIONS = setOf(
+            "cr2", "cr3", "nef", "arw", "dng", "orf", "srw",
+            "raf", "rw2", "pef", "sr2", "srf", "rwl", "x3f"
+        )
         private val VIDEO_EXTENSIONS = setOf(
             "mp4", "mov", "avi", "mkv", "wmv"
         )
@@ -62,6 +65,7 @@ class MediaFileScanner {
     private fun getMediaType(extension: String): MediaType? {
         return when {
             PHOTO_EXTENSIONS.contains(extension) -> MediaType.PHOTO
+            RAW_EXTENSIONS.contains(extension) -> MediaType.RAW
             VIDEO_EXTENSIONS.contains(extension) -> MediaType.VIDEO
             else -> null
         }

--- a/src/main/java/com/github/bfalmeida/photosync/service/MediaFileScanner.kt
+++ b/src/main/java/com/github/bfalmeida/photosync/service/MediaFileScanner.kt
@@ -16,10 +16,7 @@ class MediaFileScanner {
         private val PHOTO_EXTENSIONS = setOf(
             "jpg", "jpeg", "png", "gif", "bmp", "heic", "heif"
         )
-        private val RAW_EXTENSIONS = setOf(
-            "cr2", "cr3", "nef", "arw", "dng", "orf", "srw",
-            "raf", "rw2", "pef", "sr2", "srf", "rwl", "x3f"
-        )
+        private val RAW_EXTENSIONS = setOf("cr2", "cr3", "nef", "arw", "dng", "orf", "srw", "raf", "rw2", "pef", "sr2", "srf", "rwl", "x3f")
         private val VIDEO_EXTENSIONS = setOf(
             "mp4", "mov", "avi", "mkv", "wmv"
         )

--- a/src/main/java/com/github/bfalmeida/photosync/service/SyncService.kt
+++ b/src/main/java/com/github/bfalmeida/photosync/service/SyncService.kt
@@ -232,7 +232,11 @@ class SyncService(
 
     private fun determineDestinationPath(file: MediaFile, dateTime: LocalDateTime?, destinationRoot: Path, undatedFolder: String?): Path {
         val folderName = if (undatedFolder.isNullOrEmpty()) "undated" else undatedFolder
-        val typeFolder = if (file.mediaType == MediaType.PHOTO) "Photos" else "Videos"
+        val typeFolder = when (file.mediaType) {
+            MediaType.PHOTO -> "Photos"
+            MediaType.VIDEO -> "Videos"
+            MediaType.RAW -> "raw"
+        }
 
         if (dateTime == null) {
             return destinationRoot.resolve(folderName).resolve(typeFolder).resolve(file.fileName)

--- a/src/main/java/com/github/bfalmeida/photosync/service/SyncService.kt
+++ b/src/main/java/com/github/bfalmeida/photosync/service/SyncService.kt
@@ -236,6 +236,7 @@ class SyncService(
             MediaType.PHOTO -> "Photos"
             MediaType.VIDEO -> "Videos"
             MediaType.RAW -> "raw"
+            else -> "unknown"
         }
 
         if (dateTime == null) {


### PR DESCRIPTION
## Summary

Remediates Auditor [REJECTED] report findings for RAW image support implementation.

### Changes
- **MediaFileScanner.kt**: Added missing RAW extensions: raf, rw2, pef, sr2, srf, rwl, x3f
- **FileCopyService.kt**: Fixed critical bug where RAW files were incorrectly routed to 'Videos' folder instead of 'raw'. Replaced legacy if/else with proper  expression for MediaType handling.
- **SyncService.kt**: Updated  to use consistent  expression for MediaType routing.

### Fixes
1. Missing RAW extensions: raf, rw2, pef, sr2, srf, rwl, x3f
2. RAW files now correctly routed to 'raw' directory instead of 'Videos'
3. Consistent routing logic across FileCopyService and SyncService

### Auditor Verification
Ready for Auditor approval verification.