### PR TITLE
feature: Lazy UI Initialization (Task 3)

### DIFF
--- a/src/main/java/com/github/bfalmeida/photosync/ui/MainWindow.java
+++ b/src/main/java/com/github/bfalmeida/photosync/ui/MainWindow.java
@@ -10,6 +10,7 @@ import javax.swing.*;
 import java.awt.*;
 
 @Component
+@org.springframework.context.annotation.Lazy
 public class MainWindow extends JFrame {
     private static final Logger log = LoggerFactory.getLogger(MainWindow.class);
     


### PR DESCRIPTION
Marks MainWindow as @Lazy to ensure the application can boot in headless environments (CLI mode) without attempting to initialize the GUI.