### PR TITLE
feature: CLI Flag Filter (Task 5)

### DIFF
--- a/src/main/java/com/github/bfalmeida/photosync/PhotosyncApplication.java
+++ b/src/main/java/com/github/bfalmeida/photosync/PhotosyncApplication.java
@@ -4,21 +4,33 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 @SpringBootApplication
 @EnableScheduling
 public class PhotosyncApplication {
     public static void main(String[] args) {
-        boolean cliMode = Arrays.asList(args).contains("--cli");
+        System.out.println("[VANGUARD-BOOT] Initializing la-Kernel...");
+        
+        List<String> argList = new ArrayList<>(Arrays.asList(args));
+        boolean cliMode = argList.contains("--cli");
         
         if (cliMode) {
-            System.out.println(">>> Launching in CLI Mode...");
-            SpringApplication.run(PhotosyncApplication.class, args);
+            System.out.println("[VANGUARD-BOOT] Mode: CLI");
+            // Remove the flag so Spring Shell doesn't try to execute it as a command
+            argList.remove("--cli");
         } else {
-            System.out.println(">>> Launching in GUI Mode...");
-            // Ensure the JVM doesn't exit if the GUI is the only thing running
-            SpringApplication.run(PhotosyncApplication.class, args);
+            System.out.println("[VANGUARD-BOOT] Mode: GUI");
+        }
+
+        try {
+            SpringApplication.run(PhotosyncApplication.class, argList.toArray(new String[0]));
+        } catch (Exception e) {
+            System.err.println("[VANGUARD-FATAL] la-Kernel Crash detected:");
+            e.printStackTrace();
+            System.exit(1);
         }
     }
 }


### PR DESCRIPTION
Strips the --cli flag from the argument list before passing it to SpringApplication.run, preventing the la-Shell from attempting to execute the flag as a command.