### PR TITLE
fix: SyncServiceTest constructor mismatch

### DIFF
--- a/src/test/java/com/github/bfalmeida/photosync/service/SyncServiceTest.java
+++ b/src/test/java/com/github/bfalmeida/photosync/service/SyncServiceTest.java
@@ -47,7 +47,7 @@ class SyncServiceTest {
         Files.createDirectories(source);
         Files.createDirectories(dest);
 
-        SyncSettings settings = new SyncSettings(source, dest, true, "undated", false, false, "test-session");
+        SyncSettings settings = new SyncSettings(source, dest, true, "undated", false, false, "test-session", true);
         
         // Mock scanner to return empty for basic flow
         when(scanner.scan(any())).thenReturn(java.util.stream.Stream.empty());


### PR DESCRIPTION
This PR fixes the constructor mismatch in SyncServiceTest for SyncSettings.