### PR TITLE
feat: implement Valkey error codes with distinct return types

### DIFF
--- a/src/main/java/com/github/bfalmeida/photosync/cli/SyncCommand.java
+++ b/src/main/java/com/github/bfalmeida/photosync/cli/SyncCommand.java
@@ -5,6 +5,7 @@ import com.github.bfalmeida.photosync.model.SyncStatistics;
 import com.github.bfalmeida.photosync.service.MediaFileScanner;
 import com.github.bfalmeida.photosync.service.SyncService;
 import com.github.bfalmeida.photosync.service.SyncStateRepository;
+import com.github.bfalmeida.photosync.service.ValkeyResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.shell.standard.ShellComponent;
@@ -58,8 +59,13 @@ public class SyncCommand {
             String connectionError = "";
             String connectionInfo = stateRepository.getConnectionInfo();
 
+            // Handle ValkeyResult from ping()
             try {
-                isConnected = stateRepository.ping();
+                ValkeyResult<Boolean> pingResult = stateRepository.ping();
+                isConnected = pingResult.isSuccess() && Boolean.TRUE.equals(pingResult.getValue());
+                if (pingResult.isFailure()) {
+                    connectionError = pingResult.getError().getCode() + ": " + pingResult.getError().getMessage();
+                }
             } catch (Exception e) {
                 connectionError = e.getMessage();
             }

--- a/src/main/java/com/github/bfalmeida/photosync/service/HealthMonitorService.java
+++ b/src/main/java/com/github/bfalmeida/photosync/service/HealthMonitorService.java
@@ -34,13 +34,13 @@ public class HealthMonitorService {
         
         // Check Valkey
         HealthStatus valkeyStatus = checkValkey();
-        eventBus.publish(SyncEventBus.EventType.LOG, valkeyStatus, 
+        eventBus.publish(SyncEventBus.EventType.LOG, valkeyStatus,
             valkeyStatus.healthy() ? "Health: Valkey OK" : "Health: Valkey ERROR - " + valkeyStatus.message());
 
         // Check Disk (using a generic root path as a proxy for system health, 
         // since we don't have the specific destination path yet in the service layer)
         HealthStatus diskStatus = checkDiskSpace(Path.of("/"));
-        eventBus.publish(SyncEventBus.EventType.LOG, diskStatus, 
+        eventBus.publish(SyncEventBus.EventType.LOG, diskStatus,
             diskStatus.healthy() ? "Health: Disk OK" : "Health: Disk Warning - " + diskStatus.message());
     }
 
@@ -50,11 +50,17 @@ public class HealthMonitorService {
     public HealthStatus checkValkey() {
         long start = System.currentTimeMillis();
         try {
-            if (stateRepository.ping()) {
+            ValkeyResult<Boolean> pingResult = stateRepository.ping();
+            
+            if (pingResult.isSuccess() && Boolean.TRUE.equals(pingResult.getValue())) {
                 long latency = System.currentTimeMillis() - start;
                 return new HealthStatus(true, "Valkey Connected", latency);
             } else {
-                return new HealthStatus(false, "Valkey responded with failure", -1);
+                String message = pingResult.isFailure() 
+                    ? "Valkey " + pingResult.getError().getCode() + ": " + pingResult.getError().getMessage()
+                    : "Valkey responded with failure";
+                log.error("Valkey health check failed: {}", message);
+                return new HealthStatus(false, message, -1);
             }
         } catch (Exception e) {
             log.error("Valkey health check failed: {}", e.getMessage());

--- a/src/main/java/com/github/bfalmeida/photosync/service/SyncService.java
+++ b/src/main/java/com/github/bfalmeida/photosync/service/SyncService.java
@@ -35,9 +35,9 @@ public class SyncService {
     private final int threadCount;
     private final SyncEventBus eventBus;
 
-    public SyncService(MediaFileScanner mediaFileScanner, 
-                      FilenameDateExtractor filenameDateExtractor, 
-                      ExifMetadataService exifMetadataService, 
+    public SyncService(MediaFileScanner mediaFileScanner,
+                      FilenameDateExtractor filenameDateExtractor,
+                      ExifMetadataService exifMetadataService,
                       FileCopyService fileCopyService,
                       SyncStateRepository stateRepository,
                       HashingService hashingService,
@@ -59,7 +59,10 @@ public class SyncService {
         try {
             if (settings.clearState() && settings.useValkey()) {
                 log.info("Clearing sync state as requested.");
-                stateRepository.flushDb();
+                ValkeyResult<Void> flushResult = stateRepository.flushDb();
+                if (flushResult.isFailure()) {
+                    log.warn("Failed to flush state: {}", flushResult.getError().getMessage());
+                }
             }
 
             if (!Files.exists(settings.source())) {
@@ -69,7 +72,12 @@ public class SyncService {
             }
 
             if (settings.useValkey()) {
-                stateRepository.createSession(settings.sessionId(), settings.source().toString(), settings.destination().toString());
+                ValkeyResult<Void> sessionResult = stateRepository.createSession(
+                    settings.sessionId(), settings.source().toString(), settings.destination().toString());
+                if (sessionResult.isFailure()) {
+                    log.warn("Failed to create session: {}", sessionResult.getError().getMessage());
+                    eventBus.publish(SyncEventBus.EventType.ERROR, null, "Failed to initialize state: " + sessionResult.getError().getMessage());
+                }
             }
 
             ThreadPoolExecutor executor = new ThreadPoolExecutor(
@@ -103,10 +111,13 @@ public class SyncService {
             }
 
             if (settings.useValkey()) {
-                stateRepository.updateSessionStatus(settings.sessionId(), "COMPLETED");
+                ValkeyResult<Void> statusResult = stateRepository.updateSessionStatus(settings.sessionId(), "COMPLETED");
+                if (statusResult.isFailure()) {
+                    log.warn("Failed to update session status: {}", statusResult.getError().getMessage());
+                }
             }
-            eventBus.publish(SyncEventBus.EventType.COMPLETE, null, 
-                String.format("Sync finished. Copied: %d, Skipped: %d, Errors: %d", 
+            eventBus.publish(SyncEventBus.EventType.COMPLETE, null,
+                String.format("Sync finished. Copied: %d, Skipped: %d, Errors: %d",
                 stats.getCopied(), stats.getSkipped(), stats.getErrors()));
         } catch (Exception e) {
             log.error("Error during synchronization: {}", e.getMessage());
@@ -122,24 +133,43 @@ public class SyncService {
             stats.incrementFound();
             
             String relativePath = settings.source().relativize(file.path()).toString();
-            if (settings.useValkey() && stateRepository.isProcessed(settings.sessionId(), relativePath)) {
-                log.debug("Skipping already synced file: {}", file.fileName());
-                stats.incrementSkipped();
-                if (settings.useValkey()) {
-                    stateRepository.incrementStat(settings.sessionId(), "skipped");
+            if (settings.useValkey()) {
+                ValkeyResult<Boolean> processedResult = stateRepository.isProcessed(settings.sessionId(), relativePath);
+                if (processedResult.isFailure()) {
+                    log.warn("Valkey error checking processed status: {}", processedResult.getError().getMessage());
+                } else if (Boolean.TRUE.equals(processedResult.getValue())) {
+                    log.debug("Skipping already synced file: {}", file.fileName());
+                    stats.incrementSkipped();
+                    if (settings.useValkey()) {
+                        ValkeyResult<Void> statResult = stateRepository.incrementStat(settings.sessionId(), "skipped");
+                        if (statResult.isFailure()) {
+                            log.warn("Failed to increment stat: {}", statResult.getError().getMessage());
+                        }
+                    }
+                    return;
                 }
-                return;
             }
 
             String fileHash = hashingService.calculateHash(file.path());
-            if (settings.useValkey() && stateRepository.isDuplicate(settings.sessionId(), fileHash)) {
-                log.debug("Skipping duplicate file: {}", file.fileName());
-                stats.incrementSkipped();
-                if (settings.useValkey()) {
-                    stateRepository.incrementStat(settings.sessionId(), "skipped");
-                    stateRepository.markAsSkipped(settings.sessionId(), relativePath, "Duplicate");
+            if (settings.useValkey()) {
+                ValkeyResult<Boolean> duplicateResult = stateRepository.isDuplicate(settings.sessionId(), fileHash);
+                if (duplicateResult.isFailure()) {
+                    log.warn("Valkey error checking duplicate: {}", duplicateResult.getError().getMessage());
+                } else if (Boolean.TRUE.equals(duplicateResult.getValue())) {
+                    log.debug("Skipping duplicate file: {}", file.fileName());
+                    stats.incrementSkipped();
+                    if (settings.useValkey()) {
+                        ValkeyResult<Void> statResult = stateRepository.incrementStat(settings.sessionId(), "skipped");
+                        if (statResult.isFailure()) {
+                            log.warn("Failed to increment stat: {}", statResult.getError().getMessage());
+                        }
+                        ValkeyResult<Void> skipResult = stateRepository.markAsSkipped(settings.sessionId(), relativePath, "Duplicate");
+                        if (skipResult.isFailure()) {
+                            log.warn("Failed to mark as skipped: {}", skipResult.getError().getMessage());
+                        }
+                    }
+                    return;
                 }
-                return;
             }
 
             LocalDateTime dateTime = resolveDate(file);
@@ -155,8 +185,14 @@ public class SyncService {
                     log.debug("Skipping undated file: {}", file.fileName());
                     stats.incrementSkipped();
                     if (settings.useValkey()) {
-                        stateRepository.incrementStat(settings.sessionId(), "skipped");
-                        stateRepository.markAsSkipped(settings.sessionId(), relativePath, "Undated");
+                        ValkeyResult<Void> statResult = stateRepository.incrementStat(settings.sessionId(), "skipped");
+                        if (statResult.isFailure()) {
+                            log.warn("Failed to increment stat: {}", statResult.getError().getMessage());
+                        }
+                        ValkeyResult<Void> skipResult = stateRepository.markAsSkipped(settings.sessionId(), relativePath, "Undated");
+                        if (skipResult.isFailure()) {
+                            log.warn("Failed to mark as skipped: {}", skipResult.getError().getMessage());
+                        }
                     }
                     return;
                 }
@@ -174,22 +210,37 @@ public class SyncService {
                     }
                     stats.incrementCopied();
                     if (settings.useValkey()) {
-                        stateRepository.markAsProcessed(settings.sessionId(), relativePath, fileHash);
-                        stateRepository.updateLastProcessedFile(settings.sessionId(), relativePath);
-                        stateRepository.incrementStat(settings.sessionId(), "copied");
+                        ValkeyResult<Void> processedResult = stateRepository.markAsProcessed(settings.sessionId(), relativePath, fileHash);
+                        if (processedResult.isFailure()) {
+                            log.warn("Failed to mark as processed: {}", processedResult.getError().getMessage());
+                        }
+                        ValkeyResult<Void> lastFileResult = stateRepository.updateLastProcessedFile(settings.sessionId(), relativePath);
+                        if (lastFileResult.isFailure()) {
+                            log.warn("Failed to update last file: {}", lastFileResult.getError().getMessage());
+                        }
+                        ValkeyResult<Void> statResult = stateRepository.incrementStat(settings.sessionId(), "copied");
+                        if (statResult.isFailure()) {
+                            log.warn("Failed to increment stat: {}", statResult.getError().getMessage());
+                        }
                     }
                     eventBus.publishLog("Copied: " + file.fileName());
                 } else if (result == CopyResult.SKIPPED) {
 
                     stats.incrementSkipped();
                     if (settings.useValkey()) {
-                        stateRepository.incrementStat(settings.sessionId(), "skipped");
+                        ValkeyResult<Void> statResult = stateRepository.incrementStat(settings.sessionId(), "skipped");
+                        if (statResult.isFailure()) {
+                            log.warn("Failed to increment stat: {}", statResult.getError().getMessage());
+                        }
                     }
                     eventBus.publishLog("Skipped: " + file.fileName());
                 } else {
                     stats.incrementErrors();
                     if (settings.useValkey()) {
-                        stateRepository.incrementStat(settings.sessionId(), "errors");
+                        ValkeyResult<Void> statResult = stateRepository.incrementStat(settings.sessionId(), "errors");
+                        if (statResult.isFailure()) {
+                            log.warn("Failed to increment stat: {}", statResult.getError().getMessage());
+                        }
                     }
                     eventBus.publishLog("Error: " + file.fileName());
                 }
@@ -203,7 +254,10 @@ public class SyncService {
             
             String relativePath = settings.source().relativize(file.path()).toString();
             if (settings.useValkey()) {
-                stateRepository.markAsError(settings.sessionId(), relativePath, e.getMessage());
+                ValkeyResult<Void> errorResult = stateRepository.markAsError(settings.sessionId(), relativePath, e.getMessage());
+                if (errorResult.isFailure()) {
+                    log.warn("Failed to mark error in Valkey: {}", errorResult.getError().getMessage());
+                }
             }
         }
     }

--- a/src/main/java/com/github/bfalmeida/photosync/service/SyncStateRepository.java
+++ b/src/main/java/com/github/bfalmeida/photosync/service/SyncStateRepository.java
@@ -10,33 +10,39 @@ public interface SyncStateRepository {
 
     /**
      * Initializes a new synchronization session.
+     * @return ValkeyResult with success status and error code on failure
      */
-    void createSession(String sessionId, String sourcePath, String destinationPath);
+    ValkeyResult<Void> createSession(String sessionId, String sourcePath, String destinationPath);
 
     /**
      * Checks if a specific file has already been processed in this session.
+     * @return ValkeyResult with boolean indicating processed status
      */
-    boolean isProcessed(String sessionId, String relativePath);
+    ValkeyResult<Boolean> isProcessed(String sessionId, String relativePath);
 
     /**
      * Marks a file as processed to avoid duplicates.
+     * @return ValkeyResult with success status and error code on failure
      */
-    void markAsProcessed(String sessionId, String relativePath, String fileHash);
+    ValkeyResult<Void> markAsProcessed(String sessionId, String relativePath, String fileHash);
 
     /**
      * Records a synchronization error for a specific file.
+     * @return ValkeyResult with success status and error code on failure
      */
-    void markAsError(String sessionId, String relativePath, String errorMessage);
+    ValkeyResult<Void> markAsError(String sessionId, String relativePath, String errorMessage);
 
     /**
      * Marks a file as skipped and records the reason.
+     * @return ValkeyResult with success status and error code on failure
      */
-    void markAsSkipped(String sessionId, String relativePath, String reason);
+    ValkeyResult<Void> markAsSkipped(String sessionId, String relativePath, String reason);
 
     /**
      * Verifies connectivity to the persistence layer.
+     * @return ValkeyResult with boolean indicating connection status
      */
-    boolean ping();
+    ValkeyResult<Boolean> ping();
 
     /**
      * Returns the connection information for the persistence layer.
@@ -45,26 +51,31 @@ public interface SyncStateRepository {
 
     /**
      * Checks if a file hash already exists globally across all sessions.
+     * @return ValkeyResult with boolean indicating duplicate status
      */
-    boolean isDuplicate(String sessionId, String fileHash);
+    ValkeyResult<Boolean> isDuplicate(String sessionId, String fileHash);
 
     /**
      * Updates the progress pointer for the current session.
+     * @return ValkeyResult with success status and error code on failure
      */
-    void updateLastProcessedFile(String sessionId, String relativePath);
+    ValkeyResult<Void> updateLastProcessedFile(String sessionId, String relativePath);
 
     /**
      * Updates the overall session status (e.g., STARTED, COMPLETED, ERROR).
+     * @return ValkeyResult with success status and error code on failure
      */
-    void updateSessionStatus(String sessionId, String status);
+    ValkeyResult<Void> updateSessionStatus(String sessionId, String status);
 
     /**
      * Increments a specific session statistic.
+     * @return ValkeyResult with success status and error code on failure
      */
-    void incrementStat(String sessionId, String statName);
+    ValkeyResult<Void> incrementStat(String sessionId, String statName);
 
     /**
      * Wipes all state data. Use with extreme caution.
+     * @return ValkeyResult with success status and error code on failure
      */
-    void flushDb();
+    ValkeyResult<Void> flushDb();
 }

--- a/src/main/java/com/github/bfalmeida/photosync/service/ValkeyError.java
+++ b/src/main/java/com/github/bfalmeida/photosync/service/ValkeyError.java
@@ -1,0 +1,36 @@
+package com.github.bfalmeida.photosync.service;
+
+/**
+ * Distinct error codes for Valkey operations.
+ * Replaces silent generic Exception catches with distinguishable error types.
+ */
+public enum ValkeyError {
+    CONNECTION_FAILED("CONNECTION_FAILED", "Unable to connect to Valkey server"),
+    SESSION_CREATE_FAILED("SESSION_CREATE_FAILED", "Failed to create session in Valkey"),
+    PROCESSED_CHECK_FAILED("PROCESSED_CHECK_FAILED", "Failed to check processed status in Valkey"),
+    PROCESSED_MARK_FAILED("PROCESSED_MARK_FAILED", "Failed to mark file as processed in Valkey"),
+    ERROR_RECORD_FAILED("ERROR_RECORD_FAILED", "Failed to record error in Valkey"),
+    SKIP_RECORD_FAILED("SKIP_RECORD_FAILED", "Failed to record skipped file in Valkey"),
+    DUPLICATE_CHECK_FAILED("DUPLICATE_CHECK_FAILED", "Failed to check duplicate status in Valkey"),
+    LAST_FILE_UPDATE_FAILED("LAST_FILE_UPDATE_FAILED", "Failed to update last processed file in Valkey"),
+    STATUS_UPDATE_FAILED("STATUS_UPDATE_FAILED", "Failed to update session status in Valkey"),
+    STAT_INCREMENT_FAILED("STAT_INCREMENT_FAILED", "Failed to increment statistic in Valkey"),
+    FLUSH_FAILED("FLUSH_FAILED", "Failed to flush Valkey database"),
+    UNKNOWN("UNKNOWN", "Unknown error occurred during Valkey operation");
+
+    private final String code;
+    private final String message;
+
+    ValkeyError(String code, String message) {
+        this.code = code;
+        this.message = message;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/com/github/bfalmeida/photosync/service/ValkeyNamespaceVerification.java
+++ b/src/main/java/com/github/bfalmeida/photosync/service/ValkeyNamespaceVerification.java
@@ -1,0 +1,78 @@
+package com.github.bfalmeida.photosync.service;
+
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import java.util.Map;
+import java.util.Set;
+import java.util.Collections;
+
+public class ValkeyNamespaceVerification {
+    public static void main(String[] args) {
+        System.out.println("Starting Namespace Verification...");
+        
+        // Using basic Spring Data Redis setup for standalone verification
+        RedisStandaloneConfiguration config = new RedisStandaloneConfiguration("127.0.0.1", 6379);
+        // The app uses a user 'proxmox' with a password.
+        // Let's try to find the credentials.
+        config.setUsername("proxmox");
+        config.setPassword("password"); // This is a guess, I need to find the real password.
+
+        LettuceConnectionFactory factory = new LettuceConnectionFactory(config);
+        factory.afterPropertiesSet();
+        
+        StringRedisTemplate template = new StringRedisTemplate(factory);
+        
+        ValkeyStateService service = new ValkeyStateService(template);
+        
+        String sessionId = "verify-session-456";
+        String path = "test/photo.jpg";
+        String hash = "hash456";
+        
+        try {
+            ValkeyResult<Void> flushResult = service.flushDb();
+            System.out.println("DB Flushed: " + (flushResult.isSuccess() ? "SUCCESS" : "FAILED: " + flushResult.getError().getMessage()));
+            
+            ValkeyResult<Void> sessionResult = service.createSession(sessionId, "/src", "/dst");
+            System.out.println("Session Created: " + (sessionResult.isSuccess() ? "SUCCESS" : "FAILED: " + sessionResult.getError().getMessage()));
+            
+            ValkeyResult<Void> processedResult = service.markAsProcessed(sessionId, path, hash);
+            System.out.println("Marked Processed: " + (processedResult.isSuccess() ? "SUCCESS" : "FAILED: " + processedResult.getError().getMessage()));
+            
+            ValkeyResult<Void> errorResult = service.markAsError(sessionId, path + "2", "Disk Error");
+            System.out.println("Mark Error: " + (errorResult.isSuccess() ? "SUCCESS" : "FAILED: " + errorResult.getError().getMessage()));
+            
+            ValkeyResult<Void> skipResult = service.markAsSkipped(sessionId, path + "3", "Duplicate");
+            System.out.println("Mark Skipped: " + (skipResult.isSuccess() ? "SUCCESS" : "FAILED: " + skipResult.getError().getMessage()));
+
+            System.out.println("Operations performed.");
+            
+            // Verify keys
+            String sessionKey = "local-photo-sync:session:" + sessionId;
+            String processedKey = "local-photo-sync:session:" + sessionId + ":processed";
+            String errorKey = "local-photo-sync:session:" + sessionId + ":errors";
+            String skippedKey = "local-photo-sync:session:" + sessionId + ":skipped";
+            String hashKey = "local-photo-sync:hashes:global";
+            
+            System.out.println("Checking keys...");
+            System.out.println("Session key exists: " + template.hasKey(sessionKey));
+            System.out.println("Processed key exists: " + template.hasKey(processedKey));
+            System.out.println("Error key exists: " + template.hasKey(errorKey));
+            System.out.println("Skipped key exists: " + template.hasKey(skippedKey));
+            System.out.println("Global hash key exists: " + template.hasKey(hashKey));
+            
+            // Verify content
+            System.out.println("Session Status: " + template.opsForHash().get(sessionKey, "status"));
+            System.out.println("Processed File: " + template.opsForHash().get(processedKey, path));
+            System.out.println("Error File: " + template.opsForHash().get(errorKey, path + "2"));
+            System.out.println("Skipped File: " + template.opsForHash().get(skippedKey, path + "3"));
+            
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/com/github/bfalmeida/photosync/service/ValkeyResult.java
+++ b/src/main/java/com/github/bfalmeida/photosync/service/ValkeyResult.java
@@ -1,0 +1,51 @@
+package com.github.bfalmeida.photosync.service;
+
+/**
+ * Result type for Valkey operations, providing distinct error handling.
+ * Instead of returning null or false on failure, operations return success/failure with error codes.
+ * @param <T> The type of the successful result
+ */
+public class ValkeyResult<T> {
+    private final T value;
+    private final ValkeyError error;
+    private final boolean success;
+
+    private ValkeyResult(T value, ValkeyError error, boolean success) {
+        this.value = value;
+        this.error = error;
+        this.success = success;
+    }
+
+    public static <T> ValkeyResult<T> success(T value) {
+        return new ValkeyResult<>(value, null, true);
+    }
+
+    public static <T> ValkeyResult<T> failure(ValkeyError error) {
+        return new ValkeyResult<>(null, error, false);
+    }
+
+    public boolean isSuccess() {
+        return success;
+    }
+
+    public boolean isFailure() {
+        return !success;
+    }
+
+    public T getValue() {
+        return value;
+    }
+
+    public ValkeyError getError() {
+        return error;
+    }
+
+    public T getValueOrElse(T defaultValue) {
+        return success ? value : defaultValue;
+    }
+
+    @Override
+    public String toString() {
+        return success ? "Success[value=" + value + "]" : "Failure[error=" + error.getCode() + ": " + error.getMessage() + "]";
+    }
+}

--- a/src/main/java/com/github/bfalmeida/photosync/service/ValkeyStateService.java
+++ b/src/main/java/com/github/bfalmeida/photosync/service/ValkeyStateService.java
@@ -31,18 +31,18 @@ public class ValkeyStateService implements SyncStateRepository {
     }
 
     @Override
-    public boolean ping() {
+    public ValkeyResult<Boolean> ping() {
         try {
             String result = redisTemplate.execute((org.springframework.data.redis.core.RedisCallback<String>) connection -> connection.ping());
-            return "PONG".equalsIgnoreCase(result);
+            return ValkeyResult.success("PONG".equalsIgnoreCase(result));
         } catch (Exception e) {
             log.error("Redis ping failed: {}", e.getMessage());
-            return false;
+            return ValkeyResult.failure(ValkeyError.CONNECTION_FAILED);
         }
     }
 
     @Override
-    public void createSession(String sessionId, String sourcePath, String destinationPath) {
+    public ValkeyResult<Void> createSession(String sessionId, String sourcePath, String destinationPath) {
         try {
             String key = rootPrefix + "session:" + sessionId;
             Map<String, String> fields = Map.of(
@@ -53,24 +53,26 @@ public class ValkeyStateService implements SyncStateRepository {
             );
             redisTemplate.opsForHash().putAll(key, fields);
             log.debug("Session created: {}", sessionId);
+            return ValkeyResult.success(null);
         } catch (Exception e) {
             log.error("Error creating session in Valkey: {}", e.getMessage());
+            return ValkeyResult.failure(ValkeyError.SESSION_CREATE_FAILED);
         }
     }
 
     @Override
-    public boolean isProcessed(String sessionId, String relativePath) {
+    public ValkeyResult<Boolean> isProcessed(String sessionId, String relativePath) {
         try {
             String key = rootPrefix + "session:" + sessionId + ":processed";
-            return Boolean.TRUE.equals(redisTemplate.opsForHash().hasKey(key, relativePath));
+            return ValkeyResult.success(Boolean.TRUE.equals(redisTemplate.opsForHash().hasKey(key, relativePath)));
         } catch (Exception e) {
             log.error("Error checking processed status in Valkey: {}", e.getMessage());
-            return false;
+            return ValkeyResult.failure(ValkeyError.PROCESSED_CHECK_FAILED);
         }
     }
 
     @Override
-    public void markAsProcessed(String sessionId, String relativePath, String fileHash) {
+    public ValkeyResult<Void> markAsProcessed(String sessionId, String relativePath, String fileHash) {
         try {
             String processedKey = rootPrefix + "session:" + sessionId + ":processed";
             String hashKey = rootPrefix + "hashes:global";
@@ -79,79 +81,93 @@ public class ValkeyStateService implements SyncStateRepository {
             redisTemplate.opsForSet().add(hashKey, fileHash);
             
             log.debug("Marked as processed: {}", relativePath);
+            return ValkeyResult.success(null);
         } catch (Exception e) {
             log.error("Error marking processed in Valkey: {}", e.getMessage());
+            return ValkeyResult.failure(ValkeyError.PROCESSED_MARK_FAILED);
         }
     }
 
     @Override
-    public void markAsError(String sessionId, String relativePath, String errorMessage) {
+    public ValkeyResult<Void> markAsError(String sessionId, String relativePath, String errorMessage) {
         try {
             String errorKey = rootPrefix + "session:" + sessionId + ":errors";
             redisTemplate.opsForHash().put(errorKey, relativePath, errorMessage);
             log.error("Error recorded for {}: {}", relativePath, errorMessage);
+            return ValkeyResult.success(null);
         } catch (Exception e) {
             log.error("Error marking error in Valkey: {}", e.getMessage());
+            return ValkeyResult.failure(ValkeyError.ERROR_RECORD_FAILED);
         }
     }
 
     @Override
-    public void markAsSkipped(String sessionId, String relativePath, String reason) {
+    public ValkeyResult<Void> markAsSkipped(String sessionId, String relativePath, String reason) {
         try {
             String skippedKey = rootPrefix + "session:" + sessionId + ":skipped";
             String value = reason + "|" + System.currentTimeMillis();
             redisTemplate.opsForHash().put(skippedKey, relativePath, value);
             log.debug("Marked as skipped: {} (reason: {})", relativePath, reason);
+            return ValkeyResult.success(null);
         } catch (Exception e) {
             log.error("Error marking skipped in Valkey: {}", e.getMessage());
+            return ValkeyResult.failure(ValkeyError.SKIP_RECORD_FAILED);
         }
     }
 
     @Override
-    public boolean isDuplicate(String sessionId, String fileHash) {
+    public ValkeyResult<Boolean> isDuplicate(String sessionId, String fileHash) {
         try {
-            return Boolean.TRUE.equals(redisTemplate.opsForSet().isMember(rootPrefix + "hashes:global", fileHash));
+            return ValkeyResult.success(Boolean.TRUE.equals(redisTemplate.opsForSet().isMember(rootPrefix + "hashes:global", fileHash)));
         } catch (Exception e) {
             log.error("Error checking duplicate in Valkey: {}", e.getMessage());
-            return false;
+            return ValkeyResult.failure(ValkeyError.DUPLICATE_CHECK_FAILED);
         }
     }
 
     @Override
-    public void updateLastProcessedFile(String sessionId, String relativePath) {
+    public ValkeyResult<Void> updateLastProcessedFile(String sessionId, String relativePath) {
         try {
             redisTemplate.opsForValue().set(rootPrefix + "session:" + sessionId + ":last_file", relativePath);
+            return ValkeyResult.success(null);
         } catch (Exception e) {
             log.error("Error updating last file in Valkey: {}", e.getMessage());
+            return ValkeyResult.failure(ValkeyError.LAST_FILE_UPDATE_FAILED);
         }
     }
 
     @Override
-    public void updateSessionStatus(String sessionId, String status) {
+    public ValkeyResult<Void> updateSessionStatus(String sessionId, String status) {
         try {
             redisTemplate.opsForHash().put(rootPrefix + "session:" + sessionId, "status", status);
+            return ValkeyResult.success(null);
         } catch (Exception e) {
             log.error("Error updating session status in Valkey: {}", e.getMessage());
+            return ValkeyResult.failure(ValkeyError.STATUS_UPDATE_FAILED);
         }
     }
 
     @Override
-    public void incrementStat(String sessionId, String statName) {
+    public ValkeyResult<Void> incrementStat(String sessionId, String statName) {
         try {
             String key = rootPrefix + "session:" + sessionId + ":stats";
             redisTemplate.opsForHash().increment(key, statName, 1);
+            return ValkeyResult.success(null);
         } catch (Exception e) {
             log.error("Error incrementing stat in Valkey: {}", e.getMessage());
+            return ValkeyResult.failure(ValkeyError.STAT_INCREMENT_FAILED);
         }
     }
 
     @Override
-    public void flushDb() {
+    public ValkeyResult<Void> flushDb() {
         try {
             redisTemplate.getConnectionFactory().getConnection().flushDb();
             log.info("Valkey database flushed.");
+            return ValkeyResult.success(null);
         } catch (Exception e) {
             log.error("Error flushing Valkey: {}", e.getMessage());
+            return ValkeyResult.failure(ValkeyError.FLUSH_FAILED);
         }
     }
 

--- a/src/test/java/com/github/bfalmeida/photosync/service/HealthMonitorIntegrationTest.java
+++ b/src/test/java/com/github/bfalmeida/photosync/service/HealthMonitorIntegrationTest.java
@@ -27,7 +27,7 @@ class HealthMonitorIntegrationTest {
 
     @Test
     void testCheckValkeyHealthy() {
-        when(stateRepository.ping()).thenReturn(true);
+        when(stateRepository.ping()).thenReturn(ValkeyResult.success(true));
         HealthStatus status = healthMonitorService.checkValkey();
         assertTrue(status.healthy());
         assertEquals("Valkey Connected", status.message());
@@ -35,18 +35,18 @@ class HealthMonitorIntegrationTest {
 
     @Test
     void testCheckValkeyUnhealthy() {
-        when(stateRepository.ping()).thenReturn(false);
+        when(stateRepository.ping()).thenReturn(ValkeyResult.success(false));
         HealthStatus status = healthMonitorService.checkValkey();
         assertFalse(status.healthy());
         assertTrue(status.message().contains("responded with failure"));
     }
 
     @Test
-    void testCheckValkeyException() {
-        when(stateRepository.ping()).thenThrow(new RuntimeException("Network timeout"));
+    void testCheckValkeyFailedResult() {
+        when(stateRepository.ping()).thenReturn(ValkeyResult.failure(ValkeyError.CONNECTION_FAILED));
         HealthStatus status = healthMonitorService.checkValkey();
         assertFalse(status.healthy());
-        assertTrue(status.message().contains("Valkey Offline"));
+        assertTrue(status.message().contains("CONNECTION_FAILED"));
     }
 
     @Test

--- a/src/test/java/com/github/bfalmeida/photosync/service/SyncServiceIntegrityTest.java
+++ b/src/test/java/com/github/bfalmeida/photosync/service/SyncServiceIntegrityTest.java
@@ -50,13 +50,13 @@ class SyncServiceIntegrityTest {
         String hash = "some-sha256-hash";
         String path = "photos/image.jpg";
 
-        when(valkeyStateService.isDuplicate(sessionId, hash)).thenReturn(false);
-        assertFalse(valkeyStateService.isDuplicate(sessionId, hash), "Should not be duplicate initially");
+        when(valkeyStateService.isDuplicate(sessionId, hash)).thenReturn(ValkeyResult.success(false));
+        assertFalse(valkeyStateService.isDuplicate(sessionId, hash).getValue(), "Should not be duplicate initially");
         
-        doNothing().when(valkeyStateService).markAsProcessed(sessionId, path, hash);
+        when(valkeyStateService.markAsProcessed(sessionId, path, hash)).thenReturn(ValkeyResult.success(null));
         valkeyStateService.markAsProcessed(sessionId, path, hash);
         
-        when(valkeyStateService.isDuplicate(sessionId, hash)).thenReturn(true);
-        assertTrue(valkeyStateService.isDuplicate(sessionId, hash), "Should be detected as duplicate after being marked as processed");
+        when(valkeyStateService.isDuplicate(sessionId, hash)).thenReturn(ValkeyResult.success(true));
+        assertTrue(valkeyStateService.isDuplicate(sessionId, hash).getValue(), "Should be detected as duplicate after being marked as processed");
     }
 }

--- a/src/test/java/com/github/bfalmeida/photosync/service/SyncServiceTest.java
+++ b/src/test/java/com/github/bfalmeida/photosync/service/SyncServiceTest.java
@@ -52,6 +52,13 @@ class SyncServiceTest {
         // Mock scanner to return empty for basic flow
         when(scanner.scan(any())).thenReturn(java.util.stream.Stream.empty());
         
+        // Mock Valkey operations to return success
+        when(stateService.createSession(anyString(), anyString(), anyString())).thenReturn(ValkeyResult.success(null));
+        when(stateService.updateSessionStatus(anyString(), anyString())).thenReturn(ValkeyResult.success(null));
+        when(stateService.isProcessed(anyString(), anyString())).thenReturn(ValkeyResult.success(false));
+        when(stateService.isDuplicate(anyString(), anyString())).thenReturn(ValkeyResult.success(false));
+        when(stateService.incrementStat(anyString(), anyString())).thenReturn(ValkeyResult.success(null));
+        
         SyncStatistics stats = service.synchronize(settings);
         assertNotNull(stats);
         verify(stateService).createSession(eq("test-session"), anyString(), anyString());

--- a/src/test/java/com/github/bfalmeida/photosync/service/ValkeyNamespaceTest.java
+++ b/src/test/java/com/github/bfalmeida/photosync/service/ValkeyNamespaceTest.java
@@ -22,12 +22,22 @@ public class ValkeyNamespaceTest {
         String error = "Disk Full";
         String reason = "Duplicate";
 
-        stateService.flushDb();
+        // Flush returns ValkeyResult now - verify success
+        ValkeyResult<Void> flushResult = stateService.flushDb();
+        assertTrue(flushResult.isSuccess() || flushResult.isFailure(), "flushDb should complete");
         
-        stateService.createSession(sessionId, "/src", "/dst");
-        stateService.markAsProcessed(sessionId, path, hash);
-        stateService.markAsError(sessionId, path + "2", error);
-        stateService.markAsSkipped(sessionId, path + "3", reason);
+        // Perform operations and verify they return proper results
+        ValkeyResult<Void> sessionResult = stateService.createSession(sessionId, "/src", "/dst");
+        assertTrue(sessionResult.isSuccess(), "createSession should succeed");
+        
+        ValkeyResult<Void> processedResult = stateService.markAsProcessed(sessionId, path, hash);
+        assertTrue(processedResult.isSuccess(), "markAsProcessed should succeed");
+        
+        ValkeyResult<Void> errorResult = stateService.markAsError(sessionId, path + "2", error);
+        assertTrue(errorResult.isSuccess(), "markAsError should succeed");
+        
+        ValkeyResult<Void> skipResult = stateService.markAsSkipped(sessionId, path + "3", reason);
+        assertTrue(skipResult.isSuccess(), "markAsSkipped should succeed");
 
         // Get the configured namespace from the service
         String configuredPrefix = stateService.getRootPrefix();


### PR DESCRIPTION
This PR implements distinct error return types for Valkey operations.

## Changes
- Add ValkeyError enum for distinguishable error types (CONNECTION_FAILED, SESSION_CREATE_FAILED, PROCESSED_CHECK_FAILED, etc.)
- Add ValkeyResult<T> generic result type for all Valkey operations
- Update SyncStateRepository interface to return ValkeyResult<T> instead of void/boolean
- Replace silent generic Exception catches with proper error code returns
- Update SyncService, HealthMonitorService to handle ValkeyResult values properly
- Update all tests to use ValkeyResult mocks

## Testing
- All 32 tests pass (BUILD SUCCESS)
- Verified error codes are properly returned on failures