### PR TITLE
Fix race condition and resource leak in SyncService

### DIFF
--- a/src/main/java/com/github/bfalmeida/photosync/service/SyncService.java
+++ b/src/main/java/com/github/bfalmeida/photosync/service/SyncService.java
@@ -18,6 +18,8 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.Optional;
+import java.util.List;
+import java.util.ArrayList;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import com.github.bfalmeida.photosync.model.MediaType;
@@ -87,20 +89,32 @@ public class SyncService {
             );
 
             try {
-                var mediaFiles = mediaFileScanner.scan(settings.source()).toList();
+                var mediaFiles = mediaFileScanner.scanToList(settings.source());
                 int totalFiles = mediaFiles.size();
                 AtomicInteger processedCount = new AtomicInteger(0);
+                List<Future<?>> futures = new ArrayList<>();
 
                 eventBus.publishLog("Scanning complete. Found " + totalFiles + " files.");
 
                 for (MediaFile file : mediaFiles) {
-                    executor.submit(() -> {
+                    futures.add(executor.submit(() -> {
                         processFile(file, settings, stats);
                         
                         int current = processedCount.incrementAndGet();
                         int percent = (int) ((current * 100L) / totalFiles);
                         eventBus.publishProgress(percent, stats.getCopied(), stats.getSkipped(), stats.getErrors());
-                    });
+                    }));
+                }
+
+                // Wait for all tasks to complete before shutdown - prevents race condition
+                for (Future<?> future : futures) {
+                    try {
+                        future.get(2, TimeUnit.HOURS);
+                    } catch (TimeoutException e) {
+                        log.error("Task timed out after 2 hours", e);
+                    } catch (ExecutionException e) {
+                        log.error("Task failed with exception", e.getCause());
+                    }
                 }
             } finally {
                 executor.shutdown();

--- a/src/test/java/com/github/bfalmeida/photosync/service/SyncServiceTest.java
+++ b/src/test/java/com/github/bfalmeida/photosync/service/SyncServiceTest.java
@@ -50,7 +50,7 @@ class SyncServiceTest {
         SyncSettings settings = new SyncSettings(source, dest, true, "undated", false, false, "test-session", true, false);
         
         // Mock scanner to return empty for basic flow
-        when(scanner.scan(any())).thenReturn(java.util.stream.Stream.empty());
+        when(scanner.scanToList(any())).thenReturn(java.util.List.of());
         
         // Mock Valkey operations to return success
         when(stateService.createSession(anyString(), anyString(), anyString())).thenReturn(ValkeyResult.success(null));


### PR DESCRIPTION
## Summary
Emergency patch for two critical issues discovered in Bug Hunt:

### Issue 1: Race Condition in SyncService.synchronize()
The executor.shutdown() was called immediately after submitting tasks without waiting for them to complete. This caused tasks to potentially never execute before termination began, leading to partial sync results and data loss.

**Fix:** Track all Future objects from executor.submit() and call future.get() with timeout before shutdown.

### Issue 2: Resource Leak in MediaFileScanner.scan()
The scan() method returned an open Stream from Files.walk() without proper lifecycle management. While .toList() auto-closes streams in modern Java, using scanToList() provides explicit resource safety.

**Fix:** Changed SyncService to use scanToList() instead of scan().toList() for explicit stream management.

## Changes
- SyncService.java: Added Future tracking and waiting before executor shutdown
- SyncServiceTest.java: Updated mock to use scanToList() instead of scan()
- Added required imports: java.util.List, java.util.ArrayList

## Testing
All tests pass: mvn clean compile test-compile test ✓