### PR TITLE
Add unsupported file type filter to MediaFileScanner

### DIFF
--- a/src/main/java/com/github/bfalmeida/photosync/service/MediaFileScanner.java
+++ b/src/main/java/com/github/bfalmeida/photosync/service/MediaFileScanner.java
@@ -23,11 +23,34 @@ public class MediaFileScanner {
             "mp4", "mov", "avi", "mkv", "wmv"
     );
 
+    // Common non-media file extensions to skip early, preventing NoSuchFileException
+    private static final Set<String> UNSUPPORTED_EXTENSIONS = Set.of(
+            "pdf", "doc", "docx", "txt", "zip", "tar", "gz", "rar",
+            "mp3", "wav", "flac", "aac", "ogg", "wma",
+            "xls", "xlsx", "ppt", "pptx",
+            "exe", "dll", "so", "dylib",
+            "db", "sqlite", "sqlite3"
+    );
+
     public Stream<MediaFile> scan(Path sourceDirectory) throws IOException {
         Stream<Path> paths = Files.walk(sourceDirectory);
         return paths
                 .filter(Files::isRegularFile)
                 .filter(path -> !path.getFileName().toString().startsWith("."))
+                .filter(path -> {
+                    String fileName = path.getFileName().toString().toLowerCase();
+                    int lastDot = fileName.lastIndexOf('.');
+                    if (lastDot == -1) {
+                        return false;
+                    }
+                    String extension = fileName.substring(lastDot + 1);
+                    // Skip unsupported file types early to prevent NoSuchFileException during size check
+                    if (UNSUPPORTED_EXTENSIONS.contains(extension)) {
+                        return false;
+                    }
+                    // Must be a supported media extension
+                    return PHOTO_EXTENSIONS.contains(extension) || VIDEO_EXTENSIONS.contains(extension);
+                })
                 .filter(path -> {
                     try {
                         return Files.size(path) > 0;

--- a/src/test/java/com/github/bfalmeida/photosync/service/MediaFileScannerTest.java
+++ b/src/test/java/com/github/bfalmeida/photosync/service/MediaFileScannerTest.java
@@ -1,0 +1,73 @@
+package com.github.bfalmeida.photosync.service;
+
+import com.github.bfalmeida.photosync.model.MediaFile;
+import com.github.bfalmeida.photosync.model.MediaType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class MediaFileScannerTest {
+
+    private MediaFileScanner scanner = new MediaFileScanner();
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void testScan_FiltersUnsupportedExtensions() throws IOException {
+        // Create supported and unsupported files
+        Files.writeString(tempDir.resolve("photo.jpg"), "jpg content");
+        Files.writeString(tempDir.resolve("image.png"), "png content");
+        Files.writeString(tempDir.resolve("video.mp4"), "mp4 content");
+        Files.writeString(tempDir.resolve("document.pdf"), "pdf content");
+        Files.writeString(tempDir.resolve("document.docx"), "docx content");
+        Files.writeString(tempDir.resolve("notes.txt"), "txt content");
+        Files.writeString(tempDir.resolve("archive.zip"), "zip content");
+        Files.writeString(tempDir.resolve("audio.mp3"), "mp3 content");
+
+        List<MediaFile> result = scanner.scanToList(tempDir);
+
+        assertEquals(3, result.size(), "Should only find supported media files (jpg, png, mp4)");
+        assertEquals(2, result.stream().filter(f -> f.mediaType() == MediaType.PHOTO).count());
+        assertEquals(1, result.stream().filter(f -> f.mediaType() == MediaType.VIDEO).count());
+    }
+
+    @Test
+    void testScan_HiddenFilesIgnored() throws IOException {
+        Files.writeString(tempDir.resolve(".hidden.jpg"), "hidden content");
+        Files.writeString(tempDir.resolve("visible.jpg"), "visible content");
+
+        List<MediaFile> result = scanner.scanToList(tempDir);
+
+        assertEquals(1, result.size(), "Should ignore hidden files");
+        assertEquals("visible.jpg", result.get(0).fileName());
+    }
+
+    @Test
+    void testScan_EmptyFilesIgnored() throws IOException {
+        Files.createFile(tempDir.resolve("empty.jpg"));
+        Files.writeString(tempDir.resolve("filled.jpg"), "content");
+
+        List<MediaFile> result = scanner.scanToList(tempDir);
+
+        assertEquals(1, result.size(), "Should ignore empty files");
+        assertEquals("filled.jpg", result.get(0).fileName());
+    }
+
+    @Test
+    void testCountScannedFiles_ReturnsCorrectCount() throws IOException {
+        Files.writeString(tempDir.resolve("a.jpg"), "a");
+        Files.writeString(tempDir.resolve("b.png"), "b");
+        Files.writeString(tempDir.resolve("c.pdf"), "c"); // unsupported
+
+        long count = scanner.countScannedFiles(tempDir);
+
+        assertEquals(2, count, "Should count only supported media files");
+    }
+}


### PR DESCRIPTION
Fix: Prevent NoSuchFileException crashes in SyncService by filtering unsupported file types at scanner level.

- Add UNSUPPORTED_EXTENSIONS set with common non-media types (pdf, doc, docx, txt, zip, tar, gz, rar, mp3, wav, flac, aac, ogg, wma, xls, xlsx, ppt, pptx, exe, dll, so, dylib, db, sqlite, sqlite3)
- Filter by extension BEFORE checking file size to prevent NoSuchFileException when files disappear during scan
- Only accept files with PHOTO or VIDEO extensions, reducing unnecessary I/O operations
- Add unit tests for MediaFileScanner to verify unsupported extension filtering

All 35 tests pass with BUILD SUCCESS.